### PR TITLE
Rewrite of How to Wabbajack and the Readme

### DIFF
--- a/How To Wabbajack.md
+++ b/How To Wabbajack.md
@@ -74,3 +74,5 @@ If this Modlist receives an update, please read the Changelog before doing anyth
 This means that any additional mods you have installed on top of the Modlist will be deleted. Your downloads folder will not be touched!
 
 If you wish for Wabbajack to ignore any additional mods you've installed, rename them to say `[NoDelete]` at the beginning of the name.
+
+Updating is the same as installing. Make sure that you select the same *Installation* and *Resource Downloads* paths and tick the _overwrite installation_ button.

--- a/How To Wabbajack.md
+++ b/How To Wabbajack.md
@@ -54,7 +54,9 @@ There are a lot of different scenarios where Wabbajack will produce an error. I 
 
 Wabbajack will not work with a pirated version of the game. If you own the game on Steam, go back to the [Pre-Installation](#pre-installation) step.
 
-If the Wabbajack Installation still fails, then join the Life in the Ruins Discord as noted in the Readme.  Post a Wabbajack log file in the *wabbjack-installation-help channel*.  You can find the log files in `C:\Wabbajack\3.5.0.1\logs`.  Drag the `wabbajack.current.log` file into the help channel.
+If the Wabbajack Installation still fails, then join the Life in the Ruins Discord as noted in the [Readme](https://github.com/WhiskyTangoFawks/LunarFalloutPlus/blob/main/README.md).
+
+Post a Wabbajack log file in the *wabbjack-installation-help channel*.  You can find the log files in `C:\Wabbajack\3.5.0.1\logs`.  Drag the `wabbajack.current.log` file into the help channel.
 
 ## Updating
 

--- a/How To Wabbajack.md
+++ b/How To Wabbajack.md
@@ -1,59 +1,62 @@
-### Pre-Installation
+## Pre-Installation
 
-You need a legal copy of Fallout 4 through Steam, with all DLCs **EXCEPT** the High Definition DLC. You don't need this.
+You need a legal copy of Fallout 4 through Steam, with all DLCs **EXCEPT** the High Definition DLC.
 
-These steps are only needed if you install this Modlist for the first time. If you update the Modlist, jump straight to [Updating](#updating).
+These steps are only needed if you are installing this Modlist for the first time. If you are updating the Modlist, jump straight to [Updating](#updating).
 
-#### Installing Microsoft Visual C++ Redistributable Packages
-
+#### Installing Microsoft Visual C++ Redistributable Packages  
 These packages are required for MO2, and you can download them from [Microsoft](https://support.microsoft.com/en-us/help/2977003/the-latest-supported-visual-c-downloads)
 
-#### Steam Config
-1. Disable the Steam Overlay
+### Steam Config
+1. Disable the Steam Overlay  
+   The Steam Overlay can cause issues with ENB and is recommended to be turned off.  
+   Right click the game in your Library and select Properties.  Navigate to the _General_ tab and disable _Enable the Steam Overlay while in-game_.
 
-The Steam Overlay can cause issues with ENB and is recommended to be turned off.
+2. Clean Fallout 4  
+   Verify your game files in steam, and run the game from steam.
 
-Open the Properties window (right click the game in your Library->Properties), navigate to the _General_ tab and un-tick the _Enable the Steam Overlay while in-game_ checkbox.
+### Creating folders  
+You will need to create three folders for the installation.  One for the Wabbajack client, one for the final installation location, and one for the downloads.  The installation folder must be on an SSD.  The other two may be placed anywhere, but if the downloads are on a HDD, the installation will take significantly longer and is therefore not recommended.
+These folder must not be placed in any Window protected folder. This includes locations such as:
+- Desktop
+- Downloads
+- Documents
+- OneDrive
+- any other user folder
+- Program Files
+- Steam or Game install folders
+- Any drive root such as C:\
 
-2. Clean Fallout 4
-Verify your game files in steam, and run the game from steam.
+Use empty folders outside these locations - for example:
 
-### Using Wabbajack
+`C:\Wabbajack`  
+`C:\LifeintheRuins`  
+`C:\LifeintheRuins\downloads`
 
-#### Preparations
+The remainder of these instructions will use these exammple folders as reference.  If you decide to use different folder paths, then substitute accordingly.
 
-Let's get to the actual installation..
+## Using Wabbajack
 
-Grab the latest release of Wabbajack from [here](https://github.com/wabbajack-tools/wabbajack/releases). You need to download the `Wabbajack.exe` file ONLY. Place the `Wabbajack.exe` file in a blank folder at the root of a drive, such as `C:/Wabbajack`. Please do not put it in a Windows Protected Directory, such as Program Files or your Desktop.
+Download the latest release of Wabbajack from [here](https://github.com/wabbajack-tools/wabbajack/releases). You need to download the `Wabbajack.exe` file ONLY. Place the `Wabbajack.exe` file in `C:\Wabbajack`.
 
-Launch Wabbajack. When it is finished extracting and installing itself, select the `Browse Modlists` option. Click the Download arrow for Life In The Ruins, and you will be forwarded to the next screen when it is finished.
+Launch Wabbajack. When it is finished extracting and installing itself, select the `Browse Modlists` option. Click the Download arrow for Life In The Ruins.  Once the wabbajck file has been downloaded there will be a "play" button.  Press this button to continue.
 
-Set the `Installation Location` to a blank folder at the root of a drive, such as `D:\LifeInTheRuins`. The `Download Location` will update automatically. Again, please avoid using Windows Protected Directories.
+The Readme for the modlist will open automatically in your web browser.  It is required reading, so please take the time to read it while your installation is in progress.
+
+Set the `Modlist Installation Location` to `C:\LifeInTheRuins`  
+Set the `Resource Download Location` to `C:\LifeintheRuins\downloads`
 
 Click the `Play` arrow.
 
 ### Problems with Wabbajack
 
-There are a lot of different scenarios where Wabbajack will produce an error. I recommend re-running Wabbajack before posting anything. Wabbajack will continue where it left off so you lose no progress.
-
-**Mega links aren't downloading**:
-
-Download this manually, put the archive in your Downloads folder, and restart Wabbajack.  
- - [FO4LODGen Resources](https://mega.nz/file/BZhlVCAJ#s-GqqbnJlZDvCLPiRw1Wm1EWGqMQCuh4CR8Zzn8POM4)  
-
-**Wabbajack could not find my game folder**:
+There are a lot of different scenarios where Wabbajack will produce an error. I recommend re-running Wabbajack before posting anything. Make sure to use the same Installation and Resource Downloads folders.  Wabbajack will continue where it left off so you will not lose progress.
 
 Wabbajack will not work with a pirated version of the game. If you own the game on Steam, go back to the [Pre-Installation](#pre-installation) step.
 
-### Post-Installation
-
-#### Launching the Game
-
-Launch ModOrganizer.exe from inside your installation folder you chose for Wabbajack. Make sure the bar on the right side says `Play Life in the Ruins` and click Run. **You need to launch the game in this exact way every time in order to play with the installed mods.**
+If the Wabbajack Installation still fails, then join the Life in the Ruins Discord as noted in the Readme.  Post a Wabbajack log file in the *wabbjack-installation-help channel*.  You can find the log files in `C:\Wabbajack\3.5.0.1\logs`.  Drag the `wabbajack.current.log` file into the help channel.
 
 ## Updating
-
-If this Modlist receives an update, please check the Changelog before doing anything. Always backup your saves or start a new game after updating.
 
 Life in the Ruins updates based on a [Semantic Versioning](https://en.wikipedia.org/wiki/Software_versioning) system.
 
@@ -62,10 +65,10 @@ Generally speaking:
 - Major x.x (2.1, 2.2 etc) updates requires a new game.  
 - Minor x.x.x (2.1.1, 2.1.2) updates can be applied to an ongoing playthrough.
 
-**Wabbajack will delete all files that are not part of the Modlist when updating!**
+If this Modlist receives an update, please read the Changelog before doing anything. Any special instructions required for updating, will be noted there. Always backup your saves or start a new game after updating.
+
+**Wabbajack will delete all files from the installation folder that are not part of the Modlist when updating!**
 
 This means that any additional mods you have installed on top of the Modlist will be deleted. Your downloads folder will not be touched!
 
 If you wish for Wabbajack to ignore any additional mods you've installed, rename them to say `[NoDelete]` at the beginning of the name.
-
-Updating is like installing. You only have to make sure that you select the same path and tick the _overwrite existing Modlist_ button.

--- a/README.md
+++ b/README.md
@@ -1,30 +1,44 @@
 # Life In The Ruins: A Selection of Lunar Fallout Plus Modlists
 
-A massively overhauled and finely tuned Fallout 4 experience. Designed to rebalance the game so that the challenge comes primarily from scarcity of resources, while staying true to the vanilla asthetic. With options for a more vanilla+ style playthrough, as well as an even more challenging survival experience.
+A massively overhauled and finely tuned Fallout 4 experience. Designed to rebalance the game so that the challenge comes primarily from scarcity of resources, while staying true to the vanilla aesthetic. With options for a more vanilla+ style playthrough, as well as an even more challenging survival experience.
 
-Notice to Streamers: If you want to stream the list, join the discord and give me a heads up. I'll add you to the stream notificions for the server. I've also included a copyright free version of the music merge patch in the customisation section.
+Notice to Streamers: If you want to stream the list, join the discord and give me a heads up. I'll add you to the stream notifications for the server. I've also included a copyright free version of the music merge patch in the customization section.
 
 [Join the Community on Discord](https://discord.gg/HUNWVBjZPg)
 [Support me on Patreon](https://www.patreon.com/user?u=4257489)
 
 ## Modlist Goals
+
 - Difficulty comes from scarcity of resources, not bullet sponges.
+
 - RPG Balance, Scaling, and Progression - brought to you by Lunar Fallout Overhaul.
+
 - Strategic rather than tactical combat - prepare in advance for difficult encounters, instead of respawning until you get it right.
-- A vibrant, forested, inhabited, and uncivilised wasteland. Neglected areas should feel fleshed out, but it should still feel lonely.
+
+- A vibrant, forested, inhabited, and uncivilized wasteland. Neglected areas should feel fleshed out, but it should still feel lonely.
+
 - New Uniques - almost every single quest reward and vendor unique is now a modded weapon or armor.
+
 - Extra high-quality content with the same style and tone as vanilla (no pointlessly skimpy outfits, no tacti-cool weapons).
+
 - Full controller support (no extra configuration required).
+
 - Smooth performance on mid-range modern gaming hardware.
- 
- ### This is not...
+  
+  ### This is not...
+
 - A hardcore, nitty-gritty, track-everything-with-a-spreadsheet survival simulator
+
 - A tactical shooter
+
 - Fallout New Vegas
+
 - A good base-list for building on top of - if you want that try Welcome to Paradise or Fusion
-- A modlist that has every mod on the nexus- this is a huge list, but everything in it is hand picked, and carefully integrated to provide a focussed experience, based around an enhanced and expanded vanilla game.
- 
+
+- A modlist that has every mod on the nexus- this is a huge list, but everything in it is hand picked, and carefully integrated to provide a focused experience, based around an enhanced and expanded vanilla game.
+
 ## Key Gameplay Mods To Be Aware Of
+
 - [Lunar Fallout Overhaul](https://www.nexusmods.com/fallout4/mods/34769)
 - [True Perks](https://www.nexusmods.com/fallout4/mods/49400)
 - [Lore Based Power Armor Changes Redux](https://www.nexusmods.com/fallout4/mods/70262)
@@ -33,9 +47,10 @@ Notice to Streamers: If you want to stream the list, join the discord and give m
 - [Stimpacked - a health overhaul mod](https://www.nexusmods.com/fallout4/mods/72818)
 - [Barter Vendor Restrictions](https://www.nexusmods.com/fallout4/mods/72654)
 - [Degrade And Salvage - New Weapon Mechanics](https://www.nexusmods.com/fallout4/mods/71211)
-  
+
 ## New Content Highlights
-- [Sim Settlements 2 - Chpts 1, 2 and 3](https://www.nexusmods.com/fallout4/mods/47976)
+
+- [Sim Settlements 2 - Chapters 1, 2 and 3](https://www.nexusmods.com/fallout4/mods/47976)
 - [Tales from the Commonwealth](https://www.nexusmods.com/fallout4/mods/8704)
 - [The Fens Sheriffs Dept](https://www.nexusmods.com/fallout4/mods/68276)
 - [Subversion](https://www.nexusmods.com/fallout4/mods/50975)
@@ -43,124 +58,176 @@ Notice to Streamers: If you want to stream the list, join the discord and give m
 - [Nuka World Plus](https://www.nexusmods.com/fallout4/mods/31164)
 
 ## Profiles
+
 There are 3 profiles available
- * `Settle` : the original profile, which provides a massively overhauled and rebalanced game, including Sim Settlements 2.
- * [Wander](https://github.com/WhiskyTangoFawks/LunarFalloutPlus/blob/main/Wander.md) A less settlement focussed profile, which makes a handful of small changes (compared to the Settle modlist) geared towards the game being less settlement focussed, including the removal of SS2, and the addition of Start Me Up and an Alternate Death mod. This profile has steam deck support.
- * LunarPlus - A more vanilla+ style profile, focussed on letting Lunar Fallout Overhaul shine, without all the additional tweaks I've made to game balance. Does not include True Perks, LBPAC, SS2, or any of my survival mods. This profile also has steam deck support.
+
+* Settle : the original profile, which provides a massively overhauled and rebalanced game, including Sim Settlements 2.
+* [Wander](https://github.com/WhiskyTangoFawks/LunarFalloutPlus/blob/main/Wander.md) A less settlement focused profile, which makes a handful of small changes (compared to the Settle modlist) geared towards the game being less settlement focused, including the removal of SS2, and the addition of Start Me Up and an Alternate Death mod. This profile has steam deck support.
+* LunarPlus - A more vanilla+ style profile, focused on letting Lunar Fallout Overhaul shine, without all the additional tweaks I've made to game balance. Does not include True Perks, LBPAC, SS2, or any of my survival mods. This profile also has steam deck support.
 
 ### Optional Creation Club Content Compatibility
+
 - [Weapons and Armour Skins](https://github.com/WhiskyTangoFawks/LunarFalloutPlus/blob/main/CreationClubContent.md) Faction Distribution Framework will distribute faction based weapon and armour skins into the world- see the link for more details
- 
+
 ### [Full List of Mods at LoadOrderLibrary](https://loadorderlibrary.com/lists/life-in-the-ruins-2)
- 
+
 ## Things you should know...
+
 - Check out the [LitR Survival Tips and Tricks](https://github.com/WhiskyTangoFawks/LunarFalloutPlus/blob/main/LitR%20Tips%20and%20Tricks.md)
 
 ### Technical Requirements
-- This modlist should be installed on an SSD for performance reasons (the wabbajack download folder can be on an HDD though).
-- The main profile requires at least 6gb of Vram.
+
+- This modlist should be installed on an SSD for performance reasons (the Wabbajack download folder can be on an HDD though).
+- The main profile requires at least 6gb of VRAM.
 
 The modlist is designed for relatively modern, middle range hardware. A high end graphics card is not required, but it does help. There are performance options available, including a steam deck installation guide for the Wander Profile (I don't recommend trying to run SS2 if your hardware is going to limit your performance).
 
-#### If you have less than 6gb of vram or the list otherwise performs badly for you
+#### If you have less than 6gb of VRAM or the list otherwise performs badly for you
+
 - Do not try to run the list above 1080p, 1440 in fallout is a performance killer
 - See the readme for the wander profile- the list has a selection of performance tweaks designed to get it running on the steam deck.
 
 ## Wabbajack Installation
-See [How to Wabbajack](https://github.com/WhiskyTangoFawks/LunarFalloutPlus/blob/main/How%20To%20Wabbajack.md) for detailed instructions on using wabbajack to install the modlist
- 
+
+See [How to Wabbajack](https://github.com/WhiskyTangoFawks/LunarFalloutPlus/blob/main/How%20To%20Wabbajack.md) for detailed instructions on using Wabbajack to install the modlist
+
 See the [How To Install LitR video tutorial](https://discord.com/channels/885225427839369216/1236112171012718624/1236112171012718624)
 
 *This is a large modlist, with several large downloads, including several large sets of textures. Nexus Premium is __highly__ recommended for the initial download, expect the initial download and installation to take at least an hour with premium.*
 
 ### Solving Common Wabbajack Installation Problems
+
 * Set your game language to English if you have the game in another language- the installer does not work in other languages (it needs to find and copy the base game video files)
-* Verify you game files in steam, then run the game through steam, then repeat the installation
+* Verify your game files in steam, then run the game through steam, then repeat the installation
 * Make sure you have at least 300gb free before starting, the modlist needs some extra working space to unpack and repack the archives
-* If installation fails, and the log has "data error cyclic redundancy check", then you're file paths are too long, try something shorter like "C:\modlists\LitR"
-* Unable to download all mods - long out and then back in to the nexus in the wabbajack settings
-  
-## Additional Setup (post wabbajack installation)
-### Customisation
+* If installation fails, and the log has "data error cyclic redundancy check", then you're file paths are too long, try something shorter like "C:\LifeintheRuins"
+* Unable to download all mods - log out and then back in to the Nexus in the Wabbajack settings
+
+## Additional Setup (post Wabbajack installation)
+
+### Optional Mods and Downloads
+
 1. Creation Club: If you want to use the creation club paint job support, copy the [required Creation Club paint jobs](https://github.com/WhiskyTangoFawks/LunarFalloutPlus/blob/main/CreationClubContent.md) files from your `fallout4/data directory` into the `[NODELETE][CC] CreationClub Paint Jobs` mod folder, and enable the 5 [CC] tagged mods. Otherwise, you can skip this step.
 2. (Recommended) Download and install into the `[NODELETE] Cross Skin Packs` (found in the difficulty and customization section),  the following skin packs from https://gumroad.com/niero. They're available for free (use the discount code which can be found on the checkout page), but a donation is suggested. The man makes some fantastic mods, and you can probably afford to buy him a coffee. The links for the 2k version are provided below, however the 4k are also available.
-    * [Break Action Laser Skin Pack](https://niero.gumroad.com/l/fhdhdh)
-    * [Cross Cryolance](https://niero.gumroad.com/l/mQKCt)
-3. The `Difficulty and Customisation` section in Mod Organizer - for people who want to tweak thing a little.
-    * `Lucky 7 - Hardcore Start`: You get 7 points to spend at start instead of the regular 24, and get an extra perk point every 7 levels. For players who want a real challenge.
-    * `Fast Start - Skip Pre-War Sanctuary` Optional mod that allows you to skip the pre-war prologue
-    * `120FPS No VSYNC` : If you run a high refresh rate monitor with GSync/FreeSync, this will disable vsync, and cap the framerate at 120.
-    * `Nvidia Reflex Support` and `Nvidia Weapon Debris Crash Fix` - users with nvidia graphics cards should enable these, users with AMD graphics cards can ignore them.
-4. Field of View (FOV)
-    It is recommended to leave the FoV vanilla. If you have to change it, use BethINI or edit the ini manually. The setting can be found under Details. Setting the FoV higher than 90 has been known to cause weird visual issues with armor mods in the list. Do not use the game console to change the FOV, it will not work.
+   * [Break Action Laser Skin Pack](https://niero.gumroad.com/l/fhdhdh)
+   * [Cross Cryolance](https://niero.gumroad.com/l/mQKCt)
 
 ### Game INI Settings with BethINI
-How to Setup your own ini files with Bethini
-1. Close Mod Organizer, and open BethINI from the `Tools` folder inside your LitR installation
+
+1. Make sure Mod Organizer is not running.  Open BethINI from the `Tools` folder inside your LitR installation folder.
+
 2. `Setup` tab 
-    * Check that the game path is pointing to the `Stock Game Folder`, and not your steam installation
-    * Check that the mod organizer path is pointing to the correct instance of MO2 for Life in the Ruins.
-    * Check that your game settings path is set to `my documents/my games/fallout 4`
+   
+   * Check that the game path is pointing to the folder called `Stock Game Folder`, inside your installation folder and not your steam installation
+   * Check that the mod organizer path is pointing to the modorganizer.exe in your installation folder for Life in the Ruins.
+   * Check that your game settings path is set to `my documents/my games/fallout 4`
+
 3. `Basic` Tab
-    * Choose a profile at least one step lower than you would use for vanilla fallout. For most users with less than a 3090 I recommend medium or high, LitR is significantly heavier than vanilla fallout. (The shorter draw distances on medium make A Forest much easier to run, and A Forest makes it so you can't see stuff way in the distance anyway)
-    * For most users, 1920x1080 resolution is recommended.
-    * Enable `VSync` unless you're using Gsync/FreeSync (the `High FPS Physics Fix` mod controls VSync and this settings should be ignored, but having it match here doesn't hurt)
-    * On the custom tab, select `general` in the section drop down, and `iNumHWThreads` in the settings drop down. Set this to the number of cores your CPU has, doubling that number if it has hyperthreading. For more information on this setting, see https://stepmodifications.org/wiki/Guide:Skyrim_INI/General#iNumHWThreads
-    
+   
+   * Choose a profile at least one step lower than you would use for vanilla fallout. For most users with less than a 3090 I recommend medium or high, LitR is significantly heavier than vanilla fallout. (The shorter draw distances on medium make A Forest much easier to run, and A Forest makes it so you can't see stuff way in the distance anyway)
+   * For most users, 1920x1080 resolution is recommended.
+   * Enable `VSync` unless you're using Gsync/FreeSync (the `High FPS Physics Fix` mod controls VSync and this settings should be ignored, but having it match here doesn't hurt)
+   * On the custom tab, select `general` in the section drop down, and `iNumHWThreads` in the settings drop down. Set this to the number of cores your CPU has, doubling that number if it has hyperthreading. For more information on this setting, see https://stepmodifications.org/wiki/Guide:Skyrim_INI/General#iNumHWThreads
 
-#### Video Memory And ENBoost
+4. `Details` tab 
+   
+   * Field of View (FOV)
+     It is recommended to leave the FoV vanilla. Setting the FoV higher than 90 has been known to cause weird visual issues with armor mods in the list. It can also effect the pipboy and scopes. Do not use the game console to change the FOV, it will not work. 
 
-* [Introduction to ENBoost](https://www.youtube.com/watch?v=Y4cz-lFXDo8)
-* [How to find your optimal value with ENBoost](https://www.youtube.com/watch?v=xSz84F1kgkM)
-    - In the ENBoost section, are three presets to enable ENBoost 8k, 12k, and 16k, with the required files editted and ready to use, all you have to do is enable one of them. See the above videos for help choosing what value works best for you.
-        * Higher values might work for users with a lot of vram, but are unnessary, for most users will actually reduce performance and stability. Even with high res textures, FO4 doesn't require that much memory.
-    
-ENBoost is a feature of ENB that allows your FO4 to extend your system's VRAM with your regular RAM. It's not as fast, but it's better than nothing. AMD users with resizable BAR enabled should see even better performance improvements with this setting, and it's recommended to try it out. However this is a HIGHLY system specific setting. What works great for a user with a 3090, will crash for a user with less, which is why it's not turned on for you by default.
-
-If you have issues with textures not loading, stuttering, or the brown face bug, it is recommended to try this.
-
-#### Nvidia/AMD Control Center
+### Nvidia/AMD Control Center
 
 Settings here are going to be very system and driver specific, but some general things to be aware of
+
 * VSync settings MUST be set to application controlled 
 * Disable any framerate caps or limits
 * Make sure your drivers are up to date.
-* If you have FreeSync/Gsync enabled and an adaptive sync capable monitor, then you need either enable the 120 FPS NoVsync option in the customization section, or to make your own version of the HighFPSPhysicsFix configuration ini, to disable vsync and set the FPS cap to your desired value (however, due to the havok engine limitations, 60 or 120 is still recommended).
+* If you have FreeSync/Gsync enabled and an adaptive sync capable monitor, then you need either enable the 120 FPS NoVSYNC option in the Configuration section, or to make your own version of the HighFPSPhysicsFix configuration ini, to disable vsync and set the FPS cap to your desired value (however, due to the havok engine limitations, 60 or 120 is still recommended).
 
-### In Game Setup
-0. Start a new survival game (recommended, but not required)
-1. Mod Configuration Menu - Recommended Settings
-    * MCM Manager: Load the LitR Default settings
-    * Enable Immersive Hud if you want to use it
-2. Once you're out of the vault, use the Beantown Interiors Settings holotape to enable Hardcore Clutter, and Disable The Mad Bomber's Workshop and Colletibles crafting (these are recommended settings, but aren't required)
+### Mod Organizer Configuration
+
+Run modorganizer.exe located in the Life in the Ruins installation folder you created.
+
+1. **Video Memory And ENBoost**
+   
+   - In the ENB section, are three presets to enable ENBoost 8k, 12k, and 16k, with the required files edited and ready to use, all you have to do is enable one of them. See these videos for help choosing what value works best for you.
+     
+     - [Introduction to ENBoost](https://www.youtube.com/watch?v=Y4cz-lFXDo8)
+     
+     - [How to find your optimal value with ENBoost](https://www.youtube.com/watch?v=xSz84F1kgkM)
+   
+   - Higher values might work for users with a lot of VRAM, but are unnecessary. For most users this will actually reduce performance and stability. Even with high res textures, FO4 doesn't require that much memory.
+   
+   - ENBoost is a feature of ENB that allows your FO4 to extend your system's VRAM with your regular RAM. It's not as fast, but it's better than nothing. AMD users with resizable BAR enabled should see even better performance improvements with this setting, and it's recommended to try it out. However this is a HIGHLY system specific setting. What works great for a user with a 3090, will crash for a user with less, which is why it's not turned on for you by default.
+   
+   - If you have issues with textures not loading, stuttering, or the brown face bug, it is recommended to try this.
+
+2. **Difficulty and Customization**
+   
+   For People that want to tweak things a little.  Not all options are listed here.  See the section in Mod Organizer for all options
+   
+   - `Lucky 7 - Hardcore Start`: You get 7 points to spend at start instead of the regular 24, and get an extra perk point every 7 levels. For players who want a real challenge.
+   - `Fast Start - Skip Pre-War Sanctuary`: Optional mod that allows you to skip the pre-war prologue
+   - `Immersive HUD`: HUD when you need. HIDE when you don't.
+
+3. **Configuration** 
+   
+   Additional configuration options
+   
+   - `120FPS no VSYNC`: Enable this mod if you are using a higher refresh rate Gsync/Freesync monitor.  This mod increases the FPS cap from the High Performance Physics Fix mod  and disables vsync.  You can edit the ini file if you need additional changes, or create you own configuration file.
+   - `Whisky's Tunes`: Copyright free music for streamers
+   - `Nvidia Reflex support` and `Nvidia Weapon Debris Crash Fix`: Enable these if you have an Nvidia card.
+
+## Launching the Game and Additional in Game Setup
+
+Launch modorganizer.exe from the Life in the Ruins installation folder.
+
+1. Choose the [profile](https://github.com/WhiskyTangoFawks/LunarFalloutPlus/blob/main/README.md#profiles) you wish to use.  The default can change after an update of the list, so please check to make sure you are on your desired profile.
+
+2. Make sure the drop down next to the Run button says "Play Life in the Ruins"
+
+3. Press Run and wait for the game to launch.  Initial launch can take several minutes even on high end systems.  Do NOT press the unlock button.
+
+4. Start a new survival game (strongly recommended, but not required).  The list is balanced around survival.  There are options in the MCM in game to adjust survival settings and damage settings.
+
+5. Mod Configuration Menu
+   
+   * MCM Settings Manager: Load the LitR Default settings
+   * If you have enabled the Immersive HUD mod, you must also enable Immersive Hud in MCM if you want to use it
+
+6. Once you're out of the vault, use the Beantown Interiors Settings holotape to enable Hardcore Clutter, and Disable The Mad Bomber's Workshop and Collectibles crafting (these are recommended settings, but aren't required)
 
 ## Updating the Modlist
+
 Before updating the modlist, [see the full changelog](https://github.com/WhiskyTangoFawks/LunarFalloutPlus/blob/main/changelog.md) for the latest release. Make sure to follow any additional instructions in the changelog regarding the update process. If an update is marked as save safe, then a new save is not required.
 
-To Update the modlist, just rerun the wabbajack installer with the updated download from the wabbajack gallery (or prerelease from my patreon). Check "overwrite" during the installation process.
+To Update the modlist, just rerun the Wabbajack installer with the updated download from the Wabbajack gallery (or prerelease from my Patreon). Check "overwrite" during the installation process.
 
-- You do not need to rerun Bethini, as with Life in the Ruins the the game settings are stored in your my documents folder, not inside the list.
+- You do not need to rerun Bethini, as with Life in the Ruins the the game settings are stored in your my documents folder, not inside the list. However, it does no harm to check everything is still setup as expected.
 - You do need to reapply any MCM settings that you changed. If you're making extensive MCM changes, it is recommended to export these and back them up outside your LitR install before updating.
 
-If you still have the downloads, wabbajack will detect them and you will not need to download the entire modlist again, and the process should just take a couple minutes. If you deleted them, then yes, you will need to download all the files again.
+If you still have the downloads, Wabbajack will detect them and you will not need to download the entire modlist again, and the process should just take a couple minutes. If you deleted them, then yes, you will need to download all the files again.
 
 ## Known Issues
+
 - Performance Issues: Infinite Loading Screens, Micro Stuttering, Textures not loading, or the Brown Face bug: 
-    1. Stop other processes to free up RAM, browser windows are especially a problem here
-    2. Try setting the resolution to 1920x1080 if you're running above that
-    3. Make sure you've set iNumHWThreads, as specified in the Bethini section of this readme.
+  * Stop other processes to free up RAM, browser windows are especially a problem here
+  * Try setting the resolution to 1920x1080 if you're running above that
+  * Make sure you've set iNumHWThreads, as specified in the Bethini section of this readme.
 - SS2 script failures on new game are the result of going through the opening sequence too quickly. After you finish character creation, wait for 30 seconds or so before exiting the bathroom.
 - Crashing
-    * Medal.TV is incompatible with ENB, disable one or the other.
+  * Medal.TV is incompatible with ENB, disable one or the other.
 - Infinite Loading Screen
-    * Having your config ini's synced to one-drive. Try setting MO2 to use profile specific INIs in the profile manager dropdown.
-
+  * Having your config ini's synced to one-drive. Try setting MO2 to use profile specific INIs in the profile manager dropdown.
 
 ## Crashlog Scanner
 
-The list includes the [Buffout 4 Crashlog Auto Scanner](https://www.nexusmods.com/fallout4/mods/56255), found inside the tools folder. To use simply copy paste the crashlog from your `my documents/my games/fallout 4/f4se`, into the `tools/Scan Crash Logs Script` folder inside your LitR installation, and run the crashlog scanner from the dropdown in MO2. See the readme.md in the same folder for information on how to interpret the results.
-- Disable the `FRS` option in the scanner
+The list includes the [Buffout 4 Crashlog Auto Scanner](https://www.nexusmods.com/fallout4/mods/56255), found inside the tools\Classic Portable folder. To use it simply run the Crash Log Scanner from the dropdown in MO2. 
+
+- Disable the `FCX Mode` option in the scanner
+- Press the Scan Crash Logs button.  The scanner will automatically copy your crash logs over to it's own folder and scan them.  If your crash logs are not in the default location for some reason, you can use the Custom Scan Folder browse button to set the path.
 - The script will throw a lot of warnings in the `CHECKING FOR MODS THAT CAN CAUSE FREQUENT CRASHES...`. These can all be safely ignored, I have already dealt with all of them. You do not need to make any modifications to the mod list to deal with CTDs- these are almost always either random instability (which is expected in heavily modded FO4, but should be minimal), mis-configurations on the user end, or modifications that the user has made to the list.
+
+See the readme.md in the tools\Classic Portable folder for information on how to interpret the results.
 
 ## FAQ
 


### PR DESCRIPTION
I have edited both the Readme and How to Wabbajack files.

For the Readme:
I made a lot of changes and hopefully haven't overstepped.  One of the goals I had was to rearrange the post installation section into a logical flow of Bethini > general computer > Mod Organizer settings > In game settings.  I thought this would make more sense than having them pop in and out of Mod Organizer.

I changed some of the headers, so I may have broken some links in Discord.

I fleshed out some sections with additional details and just tried to make the instructions flow a little better.

For the How to Wabbajack file:
I added a lot of additional detail and just did a general cleanup for readability.

I also removed the Launching the Game section as I believe this belongs in the main Readme after the post installation steps.  I will be taking a pass at that next.

Removed the FO4LODGen section as it's not relevant to this list.